### PR TITLE
Adds sqlite-jdbc to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -134,6 +134,7 @@
     rum/rum {:mvn/version "0.11.3"},
     cljs-ajax/cljs-ajax {:mvn/version "0.8.0", :exclusions [commons-logging/commons-logging]},
     metosin/malli {:mvn/version "0.3.0"},
+    org.xerial/sqlite-jdbc {:mvn/version "3.46.1.3"}
     }}},
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"},


### PR DESCRIPTION
Adds dependency for sqlite driver - needed for geopackage uploads when running on macos